### PR TITLE
pyproject.toml : made explicit that Python 3.13 is not supported

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ name = "axtreme"
 version = "0.1.1"
 description = "A development library for the RaPiD project"
 readme = "README.md"
-requires-python = ">= 3.11"
+requires-python = ">= 3.11, < 3.13"
 license = { file = "LICENSE" }
 authors = [
     { name = "Sebastian Winter", email = "sebastian.winter@dnv.com" },


### PR DESCRIPTION
- [x] In pyproject.toml, made explicit that Python 3.13 is not supported
      (changed `requires-python = ">= 3.11"` to `requires-python = ">= 3.11, < 3.13"`)

closes #10 
closes #9 