### PR TITLE
General work on axtreme docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: mixed-line-ending
         args: [--fix=auto]
@@ -9,12 +9,12 @@ repos:
       - id: check-toml
       - id: check-merge-conflict
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.1
+    rev: v0.12.8
     hooks:
       - id: ruff-format
       - id: ruff
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
+    rev: v1.17.1
     hooks:
       - id: mypy
         additional_dependencies: ['numpy>=1.26.0,<2.0', torch==2.4.1]

--- a/src/axtreme/metrics.py
+++ b/src/axtreme/metrics.py
@@ -1,4 +1,4 @@
-"""Additional Metric implemenations."""
+"""Additional Metric implementations."""
 
 import copy
 from typing import TYPE_CHECKING, Any
@@ -20,7 +20,7 @@ from typing import cast
 class LocalMetadataMetric(Metric):
     """This metric retrieves its results form the trial metadata.
 
-    The simple example run the simultion within this function call
+    The simple example run the simulation within this function call
     (e.g. `see <https://ax.dev/tutorials/gpei_hartmann_developer.html#8.-Defining-custom-metrics>`_)
     In general, this method should only 'fetch' the results from somewhere else where they have been run.
     For example, Runner deploys simulation of remote, this connects to remote and collects result.
@@ -119,9 +119,9 @@ class QoIMetric(Metric):
         name: str,
         qoi_estimator: QoIEstimator,
         minimum_data_points: int = 5,
-        lower_is_better: bool | None = None,  # noqa: FBT001
-        properties: dict[str, Any] | None = None,
         *,
+        lower_is_better: bool | None = None,
+        properties: dict[str, Any] | None = None,
         attach_transforms: bool = False,
     ) -> None:
         """Initialize the QoIMetric.
@@ -129,7 +129,7 @@ class QoIMetric(Metric):
         Args:
             name: The name of the metric.
             qoi_estimator: The QoI estimator to use to calculate the metric.
-            minimum_data_points: The minimum number of datapoints the experiment must have before the GP is trained and
+            minimum_data_points: The minimum number of data points the experiment must have before the GP is trained and
                 the QoI is actually run.
             lower_is_better: Flag for metrics which should be minimized. Typically we are not interested in
                 minimising/maximising QoIs so this values should be `None`.
@@ -156,10 +156,11 @@ class QoIMetric(Metric):
         Returns:
             The data returned is effect by the total amount of data available by this trial (e.g this trial and earlier
             trials).
+
             - available data < `minimum_data-points`: `mean` and `sem` are NaN.
             - available data >= `minimum_data-points`: `mean` is the mean QoIEstimate, `sem` is the standard error of
-                the measure deviation. The standard error corresponds to the standard deviation of the distribution as
-                each sample is a prediction of the measure (the QoI).
+              the measure deviation. The standard error corresponds to the standard deviation of the distribution as
+              each sample is a prediction of the measure (the QoI).
         """
         arm = _single_arm_trial(trial)
         exp = trial.experiment


### PR DESCRIPTION
This PR contains various work done to improve the docs structure and fix docs related errors. 

The following was done:

- src/axtreme/metrics.py: 
   - fixed ruff error (FBT001 Boolean-typed positional argument in function definition) 
   - fixed indentation error in doc generation
   - corrected spelling mistakes
- updated pre-commit.yaml to the newest versions
- docs files:
   - index.rst:
      - moved some developer content to additional section to make it less overwhelming for new users 
      - moved introduction to the top to have the most relevant information for new users at the top
   - introduction.md: Included video from AI seminar as it gives a great overview of axtreme and how it works