### PR TITLE
updated to new version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     "dataclasses-json>=0.6.7",
     "gitpython>=3.1.43",
     "ax-platform[mysql]==0.3.7",
-    "plotly==6.0.1", # TODO(sw 25-05-23): Plotly 6.1.1 returns FigureWidget in place of Figure which causes many pyright attribute access issue. Need to determine which object our system should work with. See issue ##58
+    "plotly>=6.3.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Closes #58 

The comment in pyproject.toml regarding the update to the new version was that it caused pyright attribute access issues. 

I was able to reproduce the errors with version 6.1.0 of plotly. However, no pyright errors occurred when updating plotly to version 6.3.1 (the newest version). 