### PR TITLE
fixed error for doc creation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -63,7 +63,7 @@ templates_path = ["_templates"]
 exclude_patterns = []
 
 # Suppress warnings about missing top-level headers in markdown files
-# As introduction is referenced in index.rst it has not op level header
+# As introduction is referenced in index.rst it has no top level header
 # With the current setup of the build docs workflow the building fails
 # if there are warnings.
 suppress_warnings = ["myst.header"]


### PR DESCRIPTION
PR #120 introduces an unintended error in the build and publish documentation workflow as that one fails if there are any warnings. The PR introduced a warning about top-level headers in markdown files which resulted from the introduction being referenced in index.rst and therefore not having a top level header.